### PR TITLE
Add riscv64 support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,9 @@ platforms:
   ppc64el:
     build-on: [ppc64el]
     build-for: [ppc64el]
+  riscv64:
+    build-on: [riscv64]
+    build-for: [riscv64]
 
 apps:
   terminal-parrot:


### PR DESCRIPTION
This allows the snap to be packaged for RISC-V, enabling the critical terminal-parrot workflow for devices such as the Star64 and Milk-V Mars.